### PR TITLE
2nd commit

### DIFF
--- a/Js/script.js
+++ b/Js/script.js
@@ -1,41 +1,56 @@
 	
 	botao_gerar.addEventListener('click',tabuada)
 	let table_body = document.querySelector("tbody")
-	let mult = 1
+	let cont = 1
 	function tabuada(event){
-		event.preventDefault() 
+		event.preventDefault()
+		let mult = 1		
 		let number = document.getElementById('number').value
 		if (!number){
 			document.querySelector('.error').innerText = "Por favor, insira um número!"
 		} else {
 			document.querySelector('.error').innerText = "Tabuada Gerada:"
-			for (i = 1; i <= 10; i++) {
-				let linha = document.createElement("tr")
-				let coluna_numero = document.createElement("td")
-				let coluna_mult = document.createElement("td")
-				let coluna_result = document.createElement("td")
-				
-				let texto_numero = document.createTextNode(number)
-				let texto_mult = document.createTextNode(mult)
-				let texto_result = document.createTextNode(number * mult)
-				mult++
-				
-				coluna_numero.appendChild(texto_numero)
-				coluna_mult.appendChild(texto_mult)
-				coluna_result.appendChild(texto_result)
-				
-				linha.appendChild(coluna_numero)
-				linha.appendChild(coluna_mult)
-				linha.appendChild(coluna_result)
-				
-				table_body.appendChild(linha)
-			}
-			}	
-	};
-	
-	
-	
-	
+			document.getElementsByTagName("th")[0].innerText = "Número"
+			document.getElementsByTagName("th")[1].innerText = "Multiplicador" 
+			document.getElementsByTagName("th")[2].innerText = "Resultado"
+			if (cont == 1){
+				for (i = 1; i <= 10; i++) {
+					let linha = document.createElement("tr")
+					let coluna_numero = document.createElement("td")
+					let coluna_mult = document.createElement("td")
+					let coluna_result = document.createElement("td")
+			
+					let texto_numero = document.createTextNode(number)
+					let texto_mult = document.createTextNode("x "+mult)
+					let texto_result = document.createTextNode(number * mult)
+					mult++
+					
+					coluna_numero.appendChild(texto_numero)
+					coluna_mult.appendChild(texto_mult)
+					coluna_result.appendChild(texto_result)
+					
+					linha.appendChild(coluna_numero)
+					linha.appendChild(coluna_mult)
+					linha.appendChild(coluna_result)
+					
+					table_body.appendChild(linha)
+					
+				};
+				cont = 2
+			} else {
+				let selector = 0 
+				for (e = 1; e <= 29;e++){
+					document.getElementsByTagName("td")[selector].innerText = (number)
+					selector++
+					document.getElementsByTagName("td")[selector].innerText = ("x "+mult)
+					selector++
+					document.getElementsByTagName("td")[selector].innerText = (number * mult)
+					selector++
+					mult++
+				}
+			};	
+		};	
+	}
 	//PERGUNTAR PRO CAMILO: 
 	//Funcionamento do this
 	//Como é gerado o id de um objeto numa API
@@ -43,4 +58,5 @@
 	//Diferença entre separar strings de variáveis com + e vírgula
 		//Separando com vírgula, o console mostra o resultado da multiplcação em cor azul, como se fosse número.
 		//E com o sinal de mais fica tudo branco como se fosse string, mas a conta dá certo ('confused face') 
-		//Navegar entre pastas no git
+	//Upstream branch git
+		

--- a/Treinos de Lógica.html
+++ b/Treinos de Lógica.html
@@ -9,22 +9,22 @@
 	<hr>
 	<form>
 		<label for "number"> Tabuada do número: </label>
-		<input id="number" name="number" type="number" min=0 placeholder="Informe um número" autocomplete="off" required>
+		<input id="number" name="number" type="number" min=0 placeholder="Informe um número" autocomplete="off">
 		<button id="botao_gerar">Gerar Tabuada</button>
 	</form>
-	<div class="error"> </div>
-	<table>
-		<thead>
-		<tr> 
-			<th> Número </th>
-			<th> Multiplicador </th>
-			<th> Resultado </th>			
-		</tr> 
-		</thead>	
-		<tbody>
-		
-		</tbody>
-	</table>
+	<div class="error"></div> 
+		<table>
+			<thead>
+			<tr> 
+				<th></th>
+				<th></th>
+				<th></th>			
+			</tr> 
+			</thead>	
+			<tbody>
+			
+			</tbody>
+		</table>
 	<script src = "js/script.js"> </script>
 </body>
 <html>


### PR DESCRIPTION
## What?
Implementation in "tabuada" function to only generate a table on the first activation, then overwrite <td> tags values on the next loads.
## Why?
Once you've generated a multiplication table of a number, activating the function again - by clicking the button with a new number - would create a entire new table below, maintaining the old one.
## How?
1. The function now has a condition with a counter: If it's the first click, the program will create the rows and columns of table's structure; but on the next activations it will just overwrite the values of <td> tags, changing the cells.

## Screenshots (optional)

## Anything Else?
The algorithm to generate the multiplication is done, so the next step is to style everything with CSS in a new PR.